### PR TITLE
Clone form options before setting to res.locals

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -7,7 +7,8 @@ var _ = require('underscore'),
     debug = require('debug')('hmpo:form'),
     dataFormatter = require('./formatting'),
     dataValidator = require('./validation'),
-    ErrorClass = require('./error');
+    ErrorClass = require('./error'),
+    clone = require('lodash.cloneDeep');
 
 var Form = function Form(options) {
     if (!options) {
@@ -87,7 +88,7 @@ _.extend(Form.prototype, {
             errors: req.form.errors,
             errorlist: _.map(req.form.errors, _.identity),
             values: req.form.values,
-            options: this.options,
+            options: clone(this.options),
             action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
         });
         _.extend(res.locals, this.locals(req, res));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "express": "^4.12.3",
+    "lodash.clonedeep": "^4.5.0",
     "moment": "^2.9.0",
     "underscore": "^1.7.0"
   },

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -221,6 +221,15 @@ describe('Form Controller', function () {
             res.locals.options.should.eql(form.options);
         });
 
+        it('clones form options to res.locals to prevent mutation', function () {
+            form.locals = function (req, res) {
+                res.locals.options.fields.field = 'mutated';
+            };
+            form.get(req, res, cb);
+            res.locals.options.fields.field.should.equal('mutated');
+            form.options.fields.field.should.equal('name');
+        });
+
         it('emits "complete" event if form has no fields', function () {
             form.options.fields = {};
             form.get(req, res, cb);


### PR DESCRIPTION
This means that the locals options can be mutated in request pipelines without also mutating the options for all requests.

The intention for this is that the template mixins can use `locals.options.fields` to get field configuration instead of being passed a fixed fields object on instantiation, and implementing controllers can modify field config on a per-request basis.