### PR TITLE
Add `configure` method to request pipeline for dynamic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module.exports = MyForm;
 
 The Form class allows for a number of insertion points for extended functionality:
 
+* `configure`   Allows for dynamic overwriting of particular points of form configuration based on user session
 * `process`     Allows for custom formatting and processing of input prior to validation
 * `validate`    Allows for custom input validation
 * `getValues`   To define what values the fields are populated with on GET
@@ -135,6 +136,19 @@ In this example, if the last condition resolves to true - even if the others als
             return typeof req.form.values['email'] === 'undefined';
         }
     }]
+}
+```
+
+### Dynamic field options
+
+If the options for a particular field are dependent on aspects of the user session, then these can be extended on a per-session basis using the `configure` method.
+
+For example, for a dynamic address selection component:
+
+```js
+MyForm.prototype.configure = function configure(req, res, next) {
+    req.form.options.fields['address-select'].options = req.sessionModel.get('addresses');
+    next();
 }
 ```
 

--- a/lib/form.js
+++ b/lib/form.js
@@ -54,14 +54,12 @@ _.extend(Form.prototype, {
             this._getErrors.bind(this),
             this._getValues.bind(this),
             this._locals.bind(this),
+            this._checkEmpty.bind(this),
             this.render.bind(this)
         ]);
         router.use(function (err, req, res, next) {
             callback(err);
         });
-        if (_.isEmpty(this.options.fields) && this.options.next) {
-            this.emit('complete', req, res);
-        }
         router.handle(req, res, callback);
     },
     post: function (req, res, callback) {
@@ -190,6 +188,12 @@ _.extend(Form.prototype, {
     },
     getForkTarget: function (req, res) {
         return this._getForkTarget(req, res);
+    },
+    _checkEmpty: function (req, res, callback) {
+        if (_.isEmpty(req.form.options.fields) && req.form.options.next) {
+            this.emit('complete', req, res);
+        }
+        callback();
     },
     getNextStep: function (req, res) {
         var next = req.form.options.next || req.path;

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,7 +1,8 @@
 /*eslint no-unused-vars: [2, {"vars": "all", "args": "none"}]*/
 var util = require('util'),
     express = require('express'),
-    EventEmitter = require('events').EventEmitter;
+    EventEmitter = require('events').EventEmitter,
+    clone = require('lodash.clonedeep');
 
 var _ = require('underscore'),
     debug = require('debug')('hmpo:form'),
@@ -20,9 +21,6 @@ var Form = function Form(options) {
     options.fields = options.fields || {};
     this.options = options;
     this.Error = ErrorClass;
-
-    this.formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
-    this.validator = dataValidator(this.options.fields);
 
     this.router = express.Router({ mergeParams: true });
 };
@@ -50,9 +48,9 @@ _.extend(Form.prototype, {
         this.router.use.apply(this.router, arguments);
     },
     get: function (req, res, callback) {
-        req.form = req.form || {};
         var router = express.Router({ mergeParams: true });
         router.use([
+            this._configure.bind(this),
             this._getErrors.bind(this),
             this._getValues.bind(this),
             this._locals.bind(this),
@@ -68,10 +66,9 @@ _.extend(Form.prototype, {
     },
     post: function (req, res, callback) {
         this.setErrors(null, req, res);
-
-        req.form = req.form || {};
         var router = express.Router({ mergeParams: true });
         router.use([
+            this._configure.bind(this),
             this._process.bind(this),
             this._validate.bind(this),
             this.saveValues.bind(this),
@@ -87,7 +84,7 @@ _.extend(Form.prototype, {
             errors: req.form.errors,
             errorlist: _.map(req.form.errors, _.identity),
             values: req.form.values,
-            options: this.options,
+            options: req.form.options,
             action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
         });
         _.extend(res.locals, this.locals(req, res));
@@ -97,10 +94,10 @@ _.extend(Form.prototype, {
         return {};
     },
     render: function (req, res, callback) {
-        if (!this.options.template) {
+        if (!req.form.options.template) {
             callback(new Error('A template must be provided'));
         } else {
-            res.render(this.options.template);
+            res.render(req.form.options.template);
         }
     },
     _getErrors: function (req, res, callback) {
@@ -117,8 +114,11 @@ _.extend(Form.prototype, {
 
         var errors = {};
 
+        var formatter = dataFormatter(req.form.options.fields, req.form.options.defaultFormatters);
+        var validator = dataValidator(req.form.options.fields);
+
         _.each(req.form.values, function (value, key) {
-            var error = this.validateField(key, req);
+            var error = this.validateField(key, req, validator, formatter);
             if (error) {
                 if (error.group) {
                     errors[error.group] = new this.Error(error.group, error, req, res);
@@ -137,19 +137,29 @@ _.extend(Form.prototype, {
     validate: function (req, res, callback) {
         callback();
     },
-    validateField: function (key, req) {
-        var emptyValue = this.formatter(key, '');
-        return this.validator(key, req.form.values[key], req.form.values, emptyValue);
+    validateField: function (key, req, validator, formatter) {
+        formatter = formatter || dataFormatter(req.form.options.fields, req.form.options.defaultFormatters);
+        validator = validator || dataValidator(req.form.options.fields);
+        var emptyValue = formatter(key, '');
+        return validator(key, req.form.values[key], req.form.values, emptyValue);
     },
     _process: function (req, res, callback) {
-        req.form = { values: {} };
-        var formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
-        _.each(this.options.fields, function (value, key) {
+        req.form.values = req.form.values || {};
+        var formatter = dataFormatter(req.form.options.fields, req.form.options.defaultFormatters);
+        _.each(req.form.options.fields, function (value, key) {
             req.form.values[key] = formatter(key, req.body[key] || '');
         });
         this.process(req, res, callback);
     },
     process: function (req, res, callback) {
+        callback();
+    },
+    _configure: function (req, res, callback) {
+        req.form = req.form || {};
+        req.form.options = clone(this.options);
+        this.configure(req, res, callback);
+    },
+    configure: function (req, res, callback) {
         callback();
     },
     _getValues: function (req, res, callback) {
@@ -172,18 +182,18 @@ _.extend(Form.prototype, {
         }
 
         // If a fork condition is met, its target supercedes the next property
-        return this.options.forks.reduce(function (result, value) {
+        return req.form.options.forks.reduce(function (result, value) {
             return evalCondition(value.condition) ?
                 value.target :
                 result;
-        }, this.options.next);
+        }, req.form.options.next);
     },
     getForkTarget: function (req, res) {
         return this._getForkTarget(req, res);
     },
     getNextStep: function (req, res) {
-        var next = this.options.next || req.path;
-        if (this.options.forks && Array.isArray(this.options.forks)) {
+        var next = req.form.options.next || req.path;
+        if (req.form.options.forks && Array.isArray(req.form.options.forks)) {
             next = this._getForkTarget(req, res);
         }
         if (req.baseUrl !== '/') {

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -61,6 +61,7 @@ function validator(fields) {
     });
 
     return function (key, value, values, emptyValue) {
+        debug('Validating field: "' + key + '" with value: "' + value + '"');
         emptyValue = emptyValue === undefined ? '' : emptyValue;
 
         function shouldValidate() {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "express": "^4.12.3",
+    "lodash.clonedeep": "^4.5.0",
     "moment": "^2.9.0",
     "underscore": "^1.7.0"
   },

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -291,6 +291,19 @@ describe('Form Controller', function () {
             form.emit.should.have.been.calledWithExactly('complete', req, res);
         });
 
+        it('does not emit "complete" event if form has dynamic fields added at configure step', function () {
+            form.options.fields = {};
+            form.configure = function (req, res, next) {
+                req.form.options.fields.name = {
+                    mixin: 'input-text',
+                    validate: 'required'
+                };
+                next();
+            };
+            form.get(req, res, cb);
+            form.emit.withArgs('complete').should.not.have.been.called;
+        });
+
         it('does not emit "complete" event if form has fields', function () {
             form = new Form({ template: 'index', fields: { key: {} } });
             form.get(req, res, cb);


### PR DESCRIPTION
In a number of instances - particularly when wanting to set dynamic field options - implementations are mutating the global form configuration to set per-session specific config. This has significant risks in a highly concurrent multi-user environment, as changes to the global config from a user's session data can be exposed to other users.

As a result it is necessary to expose an interface to set dynamic form configuration on a per-request/per-session basis.

To do this, a `_configure` method is added to the beginning of the `get`/`post` middleware pipelines, which takes a deep clone of the form configuration and exposes it to `req.form.options`, it then calls through to an implementable `configure` method, where an implementation can safely extend the form configuration in a scope limited to a particular request cycle.

Then later stages of the middleware pipeline, where previously `this.options` was being accessed, will now access `req.form.options` to be able to read any dynamic configuration.