### PR TITLE
Amend - rewrite getErrors as a middleware function

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -104,12 +104,14 @@ _.extend(Form.prototype, {
         }
     },
     _getErrors: function (req, res, callback) {
-        req.form.errors = this.getErrors(req, res);
-        callback();
+        this.getErrors(req, res, function (err, errs) {
+            req.form.errors = errs || {};
+            callback(err);
+        });
     },
     // placeholder methods for persisting error messages between POST and GET
-    getErrors: function (/*req, res*/) {
-        return {};
+    getErrors: function (req, res, callback) {
+        callback();
     },
     setErrors: function (/*err, req, res*/) {},
     _validate: function (req, res, callback) {

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -163,7 +163,7 @@ describe('Form Controller', function () {
             };
             cb = sinon.stub();
             sinon.stub(Form.prototype, 'getValues').yields(null, {});
-            sinon.stub(Form.prototype, 'getErrors').returns({});
+            sinon.stub(Form.prototype, 'getErrors').yields(null, {});
             sinon.stub(Form.prototype, 'render');
         });
 
@@ -198,7 +198,7 @@ describe('Form Controller', function () {
         });
 
         it('passes any errors to the rendered template', function () {
-            form.getErrors.returns({ field: { message: 'error' } });
+            form.getErrors.yields(null, { field: { message: 'error' } });
             form.get(req, res, cb);
             res.locals.errors.should.eql({ field: { message: 'error' } });
         });


### PR DESCRIPTION
Rewrite getErrors to accept req, res, and callback

this is necessary:
a) for consistency with getValues
b) to enable getErrors to be applied as a middleware in child controllers