### PR TITLE
Use current error object properties when rendering message

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -25,6 +25,7 @@ module.exports = class FormError extends BaseError {
   constructor(key, options, req, res) {
     super(key, options, req, res);
     req = req || {};
+    this.options = options;
     if (typeof req.translate === 'function') {
       this.translate = req.translate;
     }
@@ -33,15 +34,15 @@ module.exports = class FormError extends BaseError {
   getMessage(key, options, req, res) {
     res = res || {};
     const keys = [
-      'validation.' + key + '.' + options.type,
-      'validation.' + key + '.default',
-      'validation.' + options.type,
+      'validation.' + this.key + '.' + this.type,
+      'validation.' + this.key + '.default',
+      'validation.' + this.type,
       'validation.default'
     ];
     const context = Object.assign({
-      label: this.translate('fields.' + key + '.label').toLowerCase(),
-      legend: this.translate('fields.' + key + '.legend').toLowerCase()
-    }, res.locals, getArgs(options.type, options.arguments));
+      label: this.translate('fields.' + this.key + '.label').toLowerCase(),
+      legend: this.translate('fields.' + this.key + '.legend').toLowerCase()
+    }, res.locals, getArgs(this.type, this.options.arguments));
 
     return i18nLookup(this.translate, compile)(keys, context);
   }

--- a/test/spec/spec.error.js
+++ b/test/spec/spec.error.js
@@ -23,6 +23,13 @@ describe('Error', () => {
       error.message.should.equal('This field is required');
     });
 
+    it('uses the current error object properties to translate the message', () => {
+      req.translate.withArgs('validation.key.custom').returns('This is a custom message');
+      const error = new ErrorClass('key', { type: 'required' }, req);
+      error.type = 'custom';
+      error.message.should.equal('This is a custom message');
+    });
+
     it('uses default error message for field if no field and type specific message is defined', () => {
       req.translate.withArgs('validation.key.default').returns('Default field message');
       const error = new ErrorClass('key', { type: 'required' }, req);


### PR DESCRIPTION
Rather than taking the properties from the arguments when the error was created, allow the `getMessage` method to use the current properties of an error instance when getting its message property.

This allows controllers to modify the properties of an error after its instantiation in order to implement custom error behaviour.

In particular, in one app we have two different fields which write to the same data point on the session, but from different places depending on context (address lookup vs manual address entry). Depending on the context, the error message for the `required` validator on that field needs to be different. If the controller can override the `key` property of that error without having to actually change the name of the field then it can display custom error messages.