### PR TITLE
Split call to form.locals into separate assign call

### DIFF
--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -91,7 +91,8 @@ module.exports = class BaseController extends EventEmitter {
       values: req.form.values,
       options: req.form.options,
       action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
-    }, this.locals(req, res));
+    });
+    Object.assign(res.locals, this.locals(req, res));
     callback();
   }
 

--- a/test/spec/spec.base-controller.js
+++ b/test/spec/spec.base-controller.js
@@ -339,6 +339,18 @@ describe('Form Controller', () => {
       res.locals.action.should.equal('/index');
     });
 
+    it('sets values to res.locals before calling controller.locals', () => {
+      let values;
+      form.getValues.yields(null, { values: [1] });
+      // need to do the assertion outside of middleware because express
+      // wraps middleware invocation in try/catch so swallows failures
+      form.locals = (_req, _res) => {
+        values = _res.locals.values;
+      };
+      form.get(req, res, cb);
+      values.should.eql({ values: [1] });
+    });
+
   });
 
   describe('post', () => {


### PR DESCRIPTION
The current implementation means that the values set to `res.locals` are not on `res.locals` when `this.locals` is called. However, the extension of this class has functionality that expects the values to exist on `res.locals` in order to populate dynamic titles.

By splitting the `Object.assign` into two calls we can be sure that `res.locals.values` exists when `this.locals` is called, and dynamic content can render correctly.