### PR TITLE
Bugfix - expose full field config in res.locals.fields

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -107,11 +107,9 @@ module.exports = class Controller extends BaseController {
     const locals = super.locals(req, res);
     const stepLocals = req.form.options.locals || {};
 
-    const fields = _.map(req.form.options.fields, (field, key) => ({
-      key,
-      mixin: field.mixin,
-      useWhen: field.useWhen
-    }));
+    const fields = _.map(req.form.options.fields, (field, key) =>
+      Object.assign({}, field, { key })
+    );
 
     return _.extend({}, locals, {
       fields,

--- a/test/spec/spec.controller.js
+++ b/test/spec/spec.controller.js
@@ -191,10 +191,12 @@ describe('lib/base-controller', () => {
         beforeEach(() => {
           req.form.options.fields = {
             'a-field': {
-              mixin: 'input-text'
+              mixin: 'input-text',
+              foo: 'bar'
             },
             'another-field': {
-              mixin: 'input-number'
+              mixin: 'input-number',
+              disableRender: true
             }
           };
           locals = controller.locals(req, res);
@@ -202,18 +204,8 @@ describe('lib/base-controller', () => {
 
         it('should have added a fields array to return object', () => {
           locals.should.have.property('fields').and.be.an('array');
-        });
-
-        it('should have added 2 items to the fields array', () => {
-          locals.fields.length.should.be.equal(2);
-        });
-
-        it('should have added \'a-field\' as \'key\' property to the first object', () => {
-          locals.fields[0].key.should.be.equal('a-field');
-        });
-
-        it('should have added \'input-text\' as \'mixin\' property to the first object', () => {
-          locals.fields[0].mixin.should.be.equal('input-text');
+          locals.fields[0].should.be.eql(Object.assign({}, req.form.options.fields['a-field'], { key: 'a-field' }));
+          locals.fields[1].should.be.eql(Object.assign({}, req.form.options.fields['another-field'], { key: 'another-field' }));
         });
       });
 


### PR DESCRIPTION
Only key, mixin and useWhen (deprecated in this regard) are exposed to the template in res.locals.fields. Amended to expose the field config extended with key so other properties can be used in the renderField mixin - in this case, `disableRender: true`