### PR TITLE
Remove autocomplete functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 2017-02-22, Version 4.0.0 (Stable), @lennym
+* Removes auto-completion of steps without fields. If needed declare this in a custom behaviour.

--- a/lib/base-controller.js
+++ b/lib/base-controller.js
@@ -57,7 +57,6 @@ module.exports = class BaseController extends EventEmitter {
         this._getErrors.bind(this),
         this._getValues.bind(this),
         this._locals.bind(this),
-        this._checkEmpty.bind(this),
         this.render.bind(this),
         // eslint-disable-next-line no-shadow
         (err, req, res, next) => {
@@ -225,13 +224,6 @@ module.exports = class BaseController extends EventEmitter {
 
   getForkTarget(req, res) {
     return this._getForkTarget(req, res);
-  }
-
-  _checkEmpty(req, res, callback) {
-    if (_.isEmpty(req.form.options.fields) && req.form.options.next) {
-      this.emit('complete', req, res);
-    }
-    callback();
   }
 
   getNextStep(req, res) {

--- a/test/spec/spec.base-controller.js
+++ b/test/spec/spec.base-controller.js
@@ -296,40 +296,6 @@ describe('Form Controller', () => {
       res.locals.options.should.eql(form.options);
     });
 
-    it('emits "complete" event if form has no fields', () => {
-      form.options.fields = {};
-      form.get(req, res, cb);
-      form.emit.withArgs('complete').should.have.been.calledOnce;
-      form.emit.withArgs('complete').should.have.been.calledOn(form);
-      form.emit.should.have.been.calledWithExactly('complete', req, res);
-    });
-
-    it('does not emit "complete" event if form has dynamic fields added at configure step', () => {
-      form.options.fields = {};
-      // eslint-disable-next-line no-shadow
-      form.configure = (req, res, next) => {
-        req.form.options.fields.name = {
-          mixin: 'input-text',
-          validate: 'required'
-        };
-        next();
-      };
-      form.get(req, res, cb);
-      form.emit.withArgs('complete').should.not.have.been.called;
-    });
-
-    it('does not emit "complete" event if form has fields', () => {
-      form = new Form({ template: 'index', fields: { key: {} } });
-      form.get(req, res, cb);
-      form.emit.withArgs('complete').should.not.have.been.called;
-    });
-
-    it('does not emit "complete" event if form has no defined next step', () => {
-      delete form.options.next;
-      form.get(req, res, cb);
-      form.emit.withArgs('complete').should.not.have.been.called;
-    });
-
     it('sets the action property on res.locals', () => {
       form.get(req, res, cb);
       res.locals.action.should.equal('/base/index');


### PR DESCRIPTION
This was intended to allow steps which have no fields, and so do not need to do anything on POST to simply link through to subsequent steps and save a round trip.

However, this is causing other steps which *do* need to perform actions on POST, and should not autocomplete, to incorrectly mark themselves complete. In particular "check answers" pages skipping directly to confirmation pages without submitting in some edge cases.

Since this behaviour is not known to be currently used, and is simple to implement as an extended behaviour, remove it.