### PR TITLE
Allow formatters to be defined as functions

### DIFF
--- a/lib/formatting/index.js
+++ b/lib/formatting/index.js
@@ -5,11 +5,11 @@ const _ = require('lodash');
 function format(f, value, formatters) {
   if (typeof f === 'string' && formatters[f]) {
     return formatters[f](value);
+  } else if (typeof f === 'function') {
+    return f(value);
   } else if (Array.isArray(f)) {
     f.forEach(v => {
-      if (formatters[v]) {
-        value = formatters[v](value);
-      }
+      value = format(v, value, formatters);
     });
   }
   return value;

--- a/test/spec/spec.base-controller.js
+++ b/test/spec/spec.base-controller.js
@@ -391,6 +391,18 @@ describe('Form Controller', () => {
       fn.should.not.throw();
     });
 
+    it('supports functions as formatters', () => {
+      form = new Form({
+        template: 'index',
+        fields: {
+          field: { formatter: ['uppercase', v => v.replace('A', 'E')] }
+        }
+      });
+      req.body.field = 'value';
+      form.post(req, res, cb);
+      req.form.values.field.should.equal('VELUE');
+    });
+
     it('applies formatter to array of values', () => {
       form = new Form({
         template: 'index',


### PR DESCRIPTION
Supports users who wish to define a formatter which is not one of the bundled list.