### PR TITLE
Allow a fork to be marked `continueOnEdit`

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -65,17 +65,22 @@ module.exports = class Controller extends BaseController {
           condition.value === req.form.values[condition.field];
       };
 
-      return evalCondition(value.condition) ?
-        normaliseUrl(value.target) :
-        result;
+      if (evalCondition(value.condition)) {
+        if (value.continueOnEdit) {
+          req.form.options.continueOnEdit = true;
+        }
+        return normaliseUrl(value.target);
+      }
+      return result;
     }, next);
-    if ((req.params.action === 'edit') && completed(next)) {
-      // The user is editing the form and has already completed the next
-      // step, so let's check whether we should fast-forward them to the
-      // confirm page
-      next = (!req.form.options.continueOnEdit || next === confirmStep) ?
-        confirmStep :
-        next + '/edit';
+
+    if (req.params.action === 'edit') {
+      if (!req.form.options.continueOnEdit && completed(next)) {
+        next = confirmStep;
+      }
+      if (next !== confirmStep) {
+        next += '/edit';
+      }
     }
 
     return next;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^2.1.1",
     "deprecate": "^1.0.0",
     "express": "^4.15.2",
-    "hof-behaviour-hooks": "^1.0.0",
+    "hof-behaviour-hooks": "^1.0.1",
     "hof-behaviour-session": "^1.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "deprecate": "^1.0.0",
-    "express": "^4.12.3",
+    "express": "^4.15.2",
     "hof-behaviour-hooks": "^1.0.0",
     "hof-behaviour-session": "^1.0.0",
     "hogan.js": "^3.0.2",

--- a/test/spec/spec.controller.js
+++ b/test/spec/spec.controller.js
@@ -375,6 +375,21 @@ describe('lib/base-controller', () => {
             controller.getNextStep(req).should.equal('/confirm');
           });
 
+          it('should follow fork if fork has `continueOnEdit` set to true', () => {
+            getStub.returns(['/target-page']);
+            req.form.values['example-radio'] = 'superman';
+            req.form.options.forks = [{
+              target: '/target-page',
+              continueOnEdit: true,
+              condition(r) {
+                return r.form.values['example-radio'] === 'superman';
+              }
+            }];
+            req.form.options.continueOnEdit = false;
+            req.params.action = 'edit';
+            controller.getNextStep(req).should.equal('/target-page/edit');
+          });
+
           it('should return /a-base-url/confirm if baseUrl is set', () => {
             getStub.returns(['/target-page']);
             req.form.values['example-radio'] = 'superman';


### PR DESCRIPTION
When we submit a forking step in an edit journey it may be the case that one option should return to /confirm and the other option should continue along the fork. For example a step that asks a "yes/no" question about adding additional addresses - "yes" should take the user around the address journey, but "no" should return the user to /confirm.

In this case allow the fork itself to have a `continueOnEdit` option, which will allow that fork to be followed in an "edit" scenario.