### PR TITLE
Allow locals to be called in a context where req.form.errors is not set

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -177,6 +177,10 @@ module.exports = class Controller extends BaseController {
 
   // eslint-disable-next-line no-unused-vars
   getErrorLength(req, res) {
+    if (!req.form.errors) {
+      return undefined;
+    }
+
     const errorLength = Object.keys(req.form.errors).length;
 
     const propName = errorLength === 1 ? 'single' : 'multiple';


### PR DESCRIPTION
Calling locals during the POST lifecycle in some behaviours (specifically PDF generation in firearms licensing app) causes an error because `req.form.errors` is undefined - since `getErrors` is not called as part of the POST pipeline.

By checking that the property exists, and responding accordingly if it does not this error can be prevented.

Also removes an unnecessary stub from the tests, which will improve the test coverage since it tests the actual behaviour of that method now.