### PR TITLE
Issue-26: more permissive email validation

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -28,7 +28,8 @@ module.exports = Validators = {
   },
 
   email(value) {
-    return value === '' || Validators.regex(value, /^[a-z0-9\._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,6}$/i);
+    // eslint-disable-next-line max-len
+    return value === '' || Validators.regex(value, /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
   },
 
   minlength(value, length) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-form-controller",
-  "version": "6.1.0",
+  "version": "6.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-form-controller",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -119,7 +119,9 @@ describe('Validators', () => {
         'test@example.com',
         'test+suffix@gmail.com',
         'test+suffix@digital.cabinet-office.gov.uk',
-        'test.suffix@digital.cabinet-office.gov.uk'
+        'test.suffix@digital.cabinet-office.gov.uk',
+        'test\'suffix@digital.cabinet-office.gov.uk',
+        'test@example.domainOverSixChars'
       ];
       inputs.forEach(i => {
         it(testName(i), () => {


### PR DESCRIPTION
## What
Allow more permissive email validation. 

https://github.com/UKHomeOfficeForms/hof-form-controller/issues/26

## Why
To allow a wider range of characters, in line with RFC5322 standard. For example this allows emails with apostrophes and longer domains to accommodate new ICANN top-level domains.
## How
Updates regex for email validator.
## Test
Added two new test cases, covering apostrophes and longer domains.
