### PR TITLE
Add new validator for internationalPhoneNumber

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -3,6 +3,7 @@
 const moment = require('moment');
 const _ = require('lodash');
 const libPhoneNumber = require('libphonenumber-js/max');
+const deprecate = require('deprecate');
 
 // validator methods should return false (or falsy value) for *invalid* input
 // and true (or truthy value) for *valid* input.
@@ -79,12 +80,24 @@ module.exports = Validators = {
   },
 
   phonenumber(value) {
+    deprecate('phonenumber validator', 'Recommend using internationalPhoneNumber for validating ' +
+      'international numbers or a different phone validator for more specific requirements.');
     return value === '' || Validators.regex(value, /^\(?\+?[\d()-]{0,15}$/);
   },
 
+  /**
+   * Validates international phone numbers (fixed and mobile) including UK.
+   * Non-GB phone numbers will require country code to validate.
+   */
+  internationalPhoneNumber(value) {
+    let phoneNumber;
+    phoneNumber = libPhoneNumber.parsePhoneNumberFromString(value, 'GB') || '';
+    return phoneNumber && (value === '' || phoneNumber.isValid());
+  },
+
   ukPhoneNumber(value) {
-      const phoneNumber = libPhoneNumber.parsePhoneNumberFromString(value, 'GB');
-      return phoneNumber && phoneNumber.isValid() && phoneNumber.country === 'GB';
+    const phoneNumber = libPhoneNumber.parsePhoneNumberFromString(value, 'GB');
+    return phoneNumber && phoneNumber.isValid() && phoneNumber.country === 'GB';
   },
 
   ukmobilephone(value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-form-controller",
-  "version": "6.1.4",
+  "version": "6.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -51,7 +51,6 @@ describe('Validators', () => {
         });
       });
     });
-
   });
 
   describe('url', () => {
@@ -295,7 +294,46 @@ describe('Validators', () => {
         });
       });
     });
+  });
 
+  describe('internationalPhoneNumber', () => {
+    describe('invalid values', function() {
+      const inputs = [
+        '123',
+        'abc',
+        'abc123',
+        '123+456',
+        '(0)+12345678',
+        '0123456789123456',
+        '0109758351'
+      ];
+      inputs.forEach(i => {
+        it(testName(i), () => {
+          Validators.internationalPhoneNumber(i).should.not.be.ok;
+        });
+      });
+    });
+
+    describe('valid values', function() {
+      const inputs = [
+        '02079460000',
+        '07900000000',
+        '+442079460000',
+        '+447900000000',
+        '+33609555167',
+        '0033609555167',
+        '020 7946 0000',
+        '+44020 79460000',
+        '+963-995-5566-40',
+        '+90-505-5578-633',
+        '+22898555987'
+      ];
+      inputs.forEach(i => {
+        it(testName(i), () => {
+          Validators.internationalPhoneNumber(i).should.be.ok;
+        });
+      });
+    });
   });
 
   describe('ukmobilephone', () => {


### PR DESCRIPTION
- Add new validator `ukOrInternationalPhoneNumber` as an improved way of validating any phone number.
- Add tests for new validator.