### PR TITLE
Allow empty strings for internationalPhoneNumber validator

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -96,7 +96,7 @@ module.exports = Validators = {
   internationalPhoneNumber(value) {
     let phoneNumber;
     phoneNumber = libPhoneNumber.parsePhoneNumberFromString(value, 'GB') || '';
-    return phoneNumber && (value === '' || phoneNumber.isValid());
+    return value === '' || (phoneNumber && phoneNumber.isValid());
   },
 
   ukPhoneNumber(value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-form-controller",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -353,6 +353,7 @@ describe('Validators', () => {
 
     describe('valid values', function() {
       const inputs = [
+        '',
         '02079460000',
         '07900000000',
         '+442079460000',


### PR DESCRIPTION
`internationalPhoneNumber()` should return true for empty strings as there is a separate validator for 'required'.

- Change logic on return to allow empty strings.
- Add an empty string to the list of test inputs for valid values.